### PR TITLE
Derive debug trait for public structs

### DIFF
--- a/src/file_store.rs
+++ b/src/file_store.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 
 type Object = Map<String, Value>;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Config {
     pub pretty: bool,
     pub indent: usize,
@@ -36,7 +36,7 @@ impl Default for Config {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FileStore {
     path: PathBuf,
     cfg: Config,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,10 @@ use memory_store::MemoryStore;
 
 pub use file_store::Config;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Store(StoreType);
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 enum StoreType {
     File(Arc<RwLock<FileStore>>, PathBuf),
     Memory(MemoryStore),

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -8,7 +8,7 @@ use std::{
 };
 use uuid::Uuid;
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct MemoryStore {
     mem: Arc<RwLock<HashMap<String, Mutex<String>>>>,
 }


### PR DESCRIPTION
I think it'll be good to have a default implementation. Without this, users cannot use `#[derive(Debug)]` on their structs that use JFS as a field. Hence users have to implement debug for the whole struct manually due to just one field.

Also see:
* https://rust-lang.github.io/api-guidelines/debuggability.html
* https://github.com/rust-lang/rust/issues/37009
* https://www.reddit.com/r/rust/comments/cw88so/derivedebug_is_poor_ergonomics