### PR TITLE
fix Access denied issue on windows

### DIFF
--- a/src/file_store.rs
+++ b/src/file_store.rs
@@ -200,13 +200,14 @@ impl FileStore {
             .open(&tmp_filename)?;
         file.lock_exclusive()?;
         tmp_file.lock_exclusive()?;
-
         match Write::write_all(&mut tmp_file, json_string.as_bytes()) {
             Err(err) => Err(err),
             Ok(_) => {
-                rename(tmp_filename, file_name)?;
                 tmp_file.unlock()?;
-                file.unlock()
+                file.unlock()?;
+                drop(file);
+                drop(tmp_file);
+                rename(tmp_filename, file_name)
             }
         }
     }


### PR DESCRIPTION
I tried to use single mode in Store configuration, it worked fine on linux but fails on windows with this error

```rust
'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 5, kind: PermissionDenied, message: "Access is denied." }
```
when investigated found that the issue is `rename` function which tries to rename a file still oppened.
so changed it to be the last call and dropped the values of `tem_file` and `file` to close the oppened files and then connect them,
also there are some problems in unit testing for windows, specially with multthreading for these methods
```rust
single_save_and_read_multi_threaded
single_new_multi_threaded
```
